### PR TITLE
Update Discovery code to use Server2 API.

### DIFF
--- a/lib/src/avahi_defs/address_resolver.dart
+++ b/lib/src/avahi_defs/address_resolver.dart
@@ -4,7 +4,7 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.AddressResolver.Found.
-class AvahiAddressResolverFound extends DBusSignal{
+class AvahiAddressResolverFound extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   int get aprotocol => (values[2] as DBusInt32).value;
@@ -12,22 +12,29 @@ class AvahiAddressResolverFound extends DBusSignal{
   String get name => (values[4] as DBusString).value;
   int get flags => (values[5] as DBusUint32).value;
 
-  AvahiAddressResolverFound(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiAddressResolverFound(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.AddressResolver.Failure.
-class AvahiAddressResolverFailure extends DBusSignal{
+class AvahiAddressResolverFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiAddressResolverFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiAddressResolverFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiAddressResolver extends DBusRemoteObject {
-  AvahiAddressResolver(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiAddressResolver(
+      DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -36,7 +43,8 @@ class AvahiAddressResolver extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.AddressResolver.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.AddressResolver', 'Free', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.AddressResolver', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.AddressResolver.Free returned invalid values \${result.values}';
     }
@@ -44,7 +52,8 @@ class AvahiAddressResolver extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.AddressResolver.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.AddressResolver', 'Start', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.AddressResolver', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.AddressResolver.Start returned invalid values \${result.values}';
     }
@@ -52,7 +61,8 @@ class AvahiAddressResolver extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.AddressResolver.Found.
   Stream<AvahiAddressResolverFound> subscribeFound() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.AddressResolver', 'Found');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.AddressResolver', 'Found');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iiissu')) {
         return AvahiAddressResolverFound(signal);
@@ -64,7 +74,8 @@ class AvahiAddressResolver extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.AddressResolver.Failure.
   Stream<AvahiAddressResolverFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.AddressResolver', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.AddressResolver', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiAddressResolverFailure(signal);

--- a/lib/src/avahi_defs/domain_browser.dart
+++ b/lib/src/avahi_defs/domain_browser.dart
@@ -4,50 +4,60 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.DomainBrowser.ItemNew.
-class AvahiDomainBrowserItemNew extends DBusSignal{
+class AvahiDomainBrowserItemNew extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get domain => (values[2] as DBusString).value;
   int get flags => (values[3] as DBusUint32).value;
 
-  AvahiDomainBrowserItemNew(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiDomainBrowserItemNew(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.DomainBrowser.ItemRemove.
-class AvahiDomainBrowserItemRemove extends DBusSignal{
+class AvahiDomainBrowserItemRemove extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get domain => (values[2] as DBusString).value;
   int get flags => (values[3] as DBusUint32).value;
 
-  AvahiDomainBrowserItemRemove(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiDomainBrowserItemRemove(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.DomainBrowser.Failure.
-class AvahiDomainBrowserFailure extends DBusSignal{
+class AvahiDomainBrowserFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiDomainBrowserFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiDomainBrowserFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.DomainBrowser.AllForNow.
-class AvahiDomainBrowserAllForNow extends DBusSignal{
-
-  AvahiDomainBrowserAllForNow(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiDomainBrowserAllForNow extends DBusSignal {
+  AvahiDomainBrowserAllForNow(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.DomainBrowser.CacheExhausted.
-class AvahiDomainBrowserCacheExhausted extends DBusSignal{
-
-  AvahiDomainBrowserCacheExhausted(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiDomainBrowserCacheExhausted extends DBusSignal {
+  AvahiDomainBrowserCacheExhausted(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiDomainBrowser extends DBusRemoteObject {
-  AvahiDomainBrowser(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiDomainBrowser(DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -56,7 +66,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.DomainBrowser.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.DomainBrowser', 'Free', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.DomainBrowser', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.DomainBrowser.Free returned invalid values \${result.values}';
     }
@@ -64,7 +75,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.DomainBrowser.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.DomainBrowser', 'Start', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.DomainBrowser', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.DomainBrowser.Start returned invalid values \${result.values}';
     }
@@ -72,7 +84,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.DomainBrowser.ItemNew.
   Stream<AvahiDomainBrowserItemNew> subscribeItemNew() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'ItemNew');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'ItemNew');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisu')) {
         return AvahiDomainBrowserItemNew(signal);
@@ -84,7 +97,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.DomainBrowser.ItemRemove.
   Stream<AvahiDomainBrowserItemRemove> subscribeItemRemove() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'ItemRemove');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'ItemRemove');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisu')) {
         return AvahiDomainBrowserItemRemove(signal);
@@ -96,7 +110,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.DomainBrowser.Failure.
   Stream<AvahiDomainBrowserFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiDomainBrowserFailure(signal);
@@ -108,7 +123,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.DomainBrowser.AllForNow.
   Stream<AvahiDomainBrowserAllForNow> subscribeAllForNow() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'AllForNow');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'AllForNow');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiDomainBrowserAllForNow(signal);
@@ -120,7 +136,8 @@ class AvahiDomainBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.DomainBrowser.CacheExhausted.
   Stream<AvahiDomainBrowserCacheExhausted> subscribeCacheExhausted() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.DomainBrowser', 'CacheExhausted');
+    var signals = subscribeSignal(
+        'org.freedesktop.Avahi.DomainBrowser', 'CacheExhausted');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiDomainBrowserCacheExhausted(signal);

--- a/lib/src/avahi_defs/host_name_resolver.dart
+++ b/lib/src/avahi_defs/host_name_resolver.dart
@@ -4,7 +4,7 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.HostNameResolver.Found.
-class AvahiHostNameResolverFound extends DBusSignal{
+class AvahiHostNameResolverFound extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get name => (values[2] as DBusString).value;
@@ -12,22 +12,29 @@ class AvahiHostNameResolverFound extends DBusSignal{
   String get address => (values[4] as DBusString).value;
   int get flags => (values[5] as DBusUint32).value;
 
-  AvahiHostNameResolverFound(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiHostNameResolverFound(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.HostNameResolver.Failure.
-class AvahiHostNameResolverFailure extends DBusSignal{
+class AvahiHostNameResolverFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiHostNameResolverFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiHostNameResolverFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiHostNameResolver extends DBusRemoteObject {
-  AvahiHostNameResolver(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiHostNameResolver(
+      DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -36,7 +43,8 @@ class AvahiHostNameResolver extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.HostNameResolver.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.HostNameResolver', 'Free', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.HostNameResolver', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.HostNameResolver.Free returned invalid values \${result.values}';
     }
@@ -44,7 +52,8 @@ class AvahiHostNameResolver extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.HostNameResolver.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.HostNameResolver', 'Start', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.HostNameResolver', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.HostNameResolver.Start returned invalid values \${result.values}';
     }
@@ -52,7 +61,8 @@ class AvahiHostNameResolver extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.HostNameResolver.Found.
   Stream<AvahiHostNameResolverFound> subscribeFound() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.HostNameResolver', 'Found');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.HostNameResolver', 'Found');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisisu')) {
         return AvahiHostNameResolverFound(signal);
@@ -64,7 +74,8 @@ class AvahiHostNameResolver extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.HostNameResolver.Failure.
   Stream<AvahiHostNameResolverFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.HostNameResolver', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.HostNameResolver', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiHostNameResolverFailure(signal);

--- a/lib/src/avahi_defs/record_browser.dart
+++ b/lib/src/avahi_defs/record_browser.dart
@@ -4,56 +4,72 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.RecordBrowser.ItemNew.
-class AvahiRecordBrowserItemNew extends DBusSignal{
+class AvahiRecordBrowserItemNew extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get name => (values[2] as DBusString).value;
   int get clazz => (values[3] as DBusUint16).value;
   int get type => (values[4] as DBusUint16).value;
-  List<int> get rdata => (values[5] as DBusArray).children.map((child) => (child as DBusByte).value).toList();
+  List<int> get rdata => (values[5] as DBusArray)
+      .children
+      .map((child) => (child as DBusByte).value)
+      .toList();
   int get flags => (values[6] as DBusUint32).value;
 
-  AvahiRecordBrowserItemNew(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiRecordBrowserItemNew(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.RecordBrowser.ItemRemove.
-class AvahiRecordBrowserItemRemove extends DBusSignal{
+class AvahiRecordBrowserItemRemove extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get name => (values[2] as DBusString).value;
   int get clazz => (values[3] as DBusUint16).value;
   int get type => (values[4] as DBusUint16).value;
-  List<int> get rdata => (values[5] as DBusArray).children.map((child) => (child as DBusByte).value).toList();
+  List<int> get rdata => (values[5] as DBusArray)
+      .children
+      .map((child) => (child as DBusByte).value)
+      .toList();
   int get flags => (values[6] as DBusUint32).value;
 
-  AvahiRecordBrowserItemRemove(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiRecordBrowserItemRemove(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.RecordBrowser.Failure.
-class AvahiRecordBrowserFailure extends DBusSignal{
+class AvahiRecordBrowserFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiRecordBrowserFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiRecordBrowserFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.RecordBrowser.AllForNow.
-class AvahiRecordBrowserAllForNow extends DBusSignal{
-
-  AvahiRecordBrowserAllForNow(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiRecordBrowserAllForNow extends DBusSignal {
+  AvahiRecordBrowserAllForNow(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.RecordBrowser.CacheExhausted.
-class AvahiRecordBrowserCacheExhausted extends DBusSignal{
-
-  AvahiRecordBrowserCacheExhausted(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiRecordBrowserCacheExhausted extends DBusSignal {
+  AvahiRecordBrowserCacheExhausted(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiRecordBrowser extends DBusRemoteObject {
-  AvahiRecordBrowser(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiRecordBrowser(DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -62,7 +78,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.RecordBrowser.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.RecordBrowser', 'Free', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.RecordBrowser', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.RecordBrowser.Free returned invalid values \${result.values}';
     }
@@ -70,7 +87,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.RecordBrowser.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.RecordBrowser', 'Start', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.RecordBrowser', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.RecordBrowser.Start returned invalid values \${result.values}';
     }
@@ -78,7 +96,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.RecordBrowser.ItemNew.
   Stream<AvahiRecordBrowserItemNew> subscribeItemNew() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'ItemNew');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'ItemNew');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisqqayu')) {
         return AvahiRecordBrowserItemNew(signal);
@@ -90,7 +109,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.RecordBrowser.ItemRemove.
   Stream<AvahiRecordBrowserItemRemove> subscribeItemRemove() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'ItemRemove');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'ItemRemove');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisqqayu')) {
         return AvahiRecordBrowserItemRemove(signal);
@@ -102,7 +122,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.RecordBrowser.Failure.
   Stream<AvahiRecordBrowserFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiRecordBrowserFailure(signal);
@@ -114,7 +135,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.RecordBrowser.AllForNow.
   Stream<AvahiRecordBrowserAllForNow> subscribeAllForNow() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'AllForNow');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'AllForNow');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiRecordBrowserAllForNow(signal);
@@ -126,7 +148,8 @@ class AvahiRecordBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.RecordBrowser.CacheExhausted.
   Stream<AvahiRecordBrowserCacheExhausted> subscribeCacheExhausted() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.RecordBrowser', 'CacheExhausted');
+    var signals = subscribeSignal(
+        'org.freedesktop.Avahi.RecordBrowser', 'CacheExhausted');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiRecordBrowserCacheExhausted(signal);

--- a/lib/src/avahi_defs/server2.dart
+++ b/lib/src/avahi_defs/server2.dart
@@ -4,19 +4,23 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.Server2.StateChanged.
-class AvahiServer2StateChanged extends DBusSignal{
+class AvahiServer2StateChanged extends DBusSignal {
   int get state => (values[0] as DBusInt32).value;
   String get error => (values[1] as DBusString).value;
 
-  AvahiServer2StateChanged(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServer2StateChanged(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiServer2 extends DBusRemoteObject {
-  AvahiServer2(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiServer2(DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -25,7 +29,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetVersionString()
   Future<String> callGetVersionString() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetVersionString', []);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'GetVersionString', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetVersionString returned invalid values \${result.values}';
     }
@@ -34,7 +39,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetAPIVersion()
   Future<int> callGetAPIVersion() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetAPIVersion', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'GetAPIVersion', []);
     if (result.signature != DBusSignature('u')) {
       throw 'org.freedesktop.Avahi.Server2.GetAPIVersion returned invalid values \${result.values}';
     }
@@ -43,7 +49,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetHostName()
   Future<String> callGetHostName() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetHostName', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'GetHostName', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetHostName returned invalid values \${result.values}';
     }
@@ -52,7 +59,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.SetHostName()
   Future<void> callSetHostName(String name) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'SetHostName', [DBusString(name)]);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'SetHostName', [DBusString(name)]);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.Server2.SetHostName returned invalid values \${result.values}';
     }
@@ -60,7 +68,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetHostNameFqdn()
   Future<String> callGetHostNameFqdn() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetHostNameFqdn', []);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'GetHostNameFqdn', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetHostNameFqdn returned invalid values \${result.values}';
     }
@@ -69,7 +78,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetDomainName()
   Future<String> callGetDomainName() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetDomainName', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'GetDomainName', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetDomainName returned invalid values \${result.values}';
     }
@@ -78,7 +88,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.IsNSSSupportAvailable()
   Future<bool> callIsNSSSupportAvailable() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'IsNSSSupportAvailable', []);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'IsNSSSupportAvailable', []);
     if (result.signature != DBusSignature('b')) {
       throw 'org.freedesktop.Avahi.Server2.IsNSSSupportAvailable returned invalid values \${result.values}';
     }
@@ -87,7 +98,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetState()
   Future<int> callGetState() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetState', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'GetState', []);
     if (result.signature != DBusSignature('i')) {
       throw 'org.freedesktop.Avahi.Server2.GetState returned invalid values \${result.values}';
     }
@@ -96,7 +108,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetLocalServiceCookie()
   Future<int> callGetLocalServiceCookie() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetLocalServiceCookie', []);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'GetLocalServiceCookie', []);
     if (result.signature != DBusSignature('u')) {
       throw 'org.freedesktop.Avahi.Server2.GetLocalServiceCookie returned invalid values \${result.values}';
     }
@@ -105,7 +118,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetAlternativeHostName()
   Future<String> callGetAlternativeHostName(String name) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetAlternativeHostName', [DBusString(name)]);
+    var result = await callMethod('org.freedesktop.Avahi.Server2',
+        'GetAlternativeHostName', [DBusString(name)]);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetAlternativeHostName returned invalid values \${result.values}';
     }
@@ -114,7 +128,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetAlternativeServiceName()
   Future<String> callGetAlternativeServiceName(String name) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetAlternativeServiceName', [DBusString(name)]);
+    var result = await callMethod('org.freedesktop.Avahi.Server2',
+        'GetAlternativeServiceName', [DBusString(name)]);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetAlternativeServiceName returned invalid values \${result.values}';
     }
@@ -123,7 +138,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetNetworkInterfaceNameByIndex()
   Future<String> callGetNetworkInterfaceNameByIndex(int index) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetNetworkInterfaceNameByIndex', [DBusInt32(index)]);
+    var result = await callMethod('org.freedesktop.Avahi.Server2',
+        'GetNetworkInterfaceNameByIndex', [DBusInt32(index)]);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.Avahi.Server2.GetNetworkInterfaceNameByIndex returned invalid values \${result.values}';
     }
@@ -132,7 +148,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.GetNetworkInterfaceIndexByName()
   Future<int> callGetNetworkInterfaceIndexByName(String name) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'GetNetworkInterfaceIndexByName', [DBusString(name)]);
+    var result = await callMethod('org.freedesktop.Avahi.Server2',
+        'GetNetworkInterfaceIndexByName', [DBusString(name)]);
     if (result.signature != DBusSignature('i')) {
       throw 'org.freedesktop.Avahi.Server2.GetNetworkInterfaceIndexByName returned invalid values \${result.values}';
     }
@@ -140,8 +157,16 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.ResolveHostName()
-  Future<List<DBusValue>> callResolveHostName(int interface, int protocol, String name, int aprotocol, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'ResolveHostName', [DBusInt32(interface), DBusInt32(protocol), DBusString(name), DBusInt32(aprotocol), DBusUint32(flags)]);
+  Future<List<DBusValue>> callResolveHostName(int interface, int protocol,
+      String name, int aprotocol, int flags) async {
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'ResolveHostName', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(name),
+      DBusInt32(aprotocol),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('iisisu')) {
       throw 'org.freedesktop.Avahi.Server2.ResolveHostName returned invalid values \${result.values}';
     }
@@ -149,8 +174,15 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.ResolveAddress()
-  Future<List<DBusValue>> callResolveAddress(int interface, int protocol, String address, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'ResolveAddress', [DBusInt32(interface), DBusInt32(protocol), DBusString(address), DBusUint32(flags)]);
+  Future<List<DBusValue>> callResolveAddress(
+      int interface, int protocol, String address, int flags) async {
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'ResolveAddress', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(address),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('iiissu')) {
       throw 'org.freedesktop.Avahi.Server2.ResolveAddress returned invalid values \${result.values}';
     }
@@ -158,8 +190,18 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.ResolveService()
-  Future<List<DBusValue>> callResolveService(int interface, int protocol, String name, String type, String domain, int aprotocol, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'ResolveService', [DBusInt32(interface), DBusInt32(protocol), DBusString(name), DBusString(type), DBusString(domain), DBusInt32(aprotocol), DBusUint32(flags)]);
+  Future<List<DBusValue>> callResolveService(int interface, int protocol,
+      String name, String type, String domain, int aprotocol, int flags) async {
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'ResolveService', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(name),
+      DBusString(type),
+      DBusString(domain),
+      DBusInt32(aprotocol),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('iissssisqaayu')) {
       throw 'org.freedesktop.Avahi.Server2.ResolveService returned invalid values \${result.values}';
     }
@@ -168,7 +210,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.Server2.EntryGroupNew()
   Future<String> callEntryGroupNew() async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'EntryGroupNew', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.Server2', 'EntryGroupNew', []);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.EntryGroupNew returned invalid values \${result.values}';
     }
@@ -176,8 +219,16 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.DomainBrowserPrepare()
-  Future<String> callDomainBrowserPrepare(int interface, int protocol, String domain, int btype, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'DomainBrowserPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(domain), DBusInt32(btype), DBusUint32(flags)]);
+  Future<String> callDomainBrowserPrepare(
+      int interface, int protocol, String domain, int btype, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'DomainBrowserPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(domain),
+      DBusInt32(btype),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.DomainBrowserPrepare returned invalid values \${result.values}';
     }
@@ -185,8 +236,15 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.ServiceTypeBrowserPrepare()
-  Future<String> callServiceTypeBrowserPrepare(int interface, int protocol, String domain, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'ServiceTypeBrowserPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(domain), DBusUint32(flags)]);
+  Future<String> callServiceTypeBrowserPrepare(
+      int interface, int protocol, String domain, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'ServiceTypeBrowserPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(domain),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.ServiceTypeBrowserPrepare returned invalid values \${result.values}';
     }
@@ -194,8 +252,16 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.ServiceBrowserPrepare()
-  Future<String> callServiceBrowserPrepare(int interface, int protocol, String type, String domain, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'ServiceBrowserPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(type), DBusString(domain), DBusUint32(flags)]);
+  Future<String> callServiceBrowserPrepare(int interface, int protocol,
+      String type, String domain, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'ServiceBrowserPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(type),
+      DBusString(domain),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.ServiceBrowserPrepare returned invalid values \${result.values}';
     }
@@ -203,8 +269,18 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.ServiceResolverPrepare()
-  Future<String> callServiceResolverPrepare(int interface, int protocol, String name, String type, String domain, int aprotocol, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'ServiceResolverPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(name), DBusString(type), DBusString(domain), DBusInt32(aprotocol), DBusUint32(flags)]);
+  Future<String> callServiceResolverPrepare(int interface, int protocol,
+      String name, String type, String domain, int aprotocol, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'ServiceResolverPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(name),
+      DBusString(type),
+      DBusString(domain),
+      DBusInt32(aprotocol),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.ServiceResolverPrepare returned invalid values \${result.values}';
     }
@@ -212,8 +288,16 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.HostNameResolverPrepare()
-  Future<String> callHostNameResolverPrepare(int interface, int protocol, String name, int aprotocol, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'HostNameResolverPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(name), DBusInt32(aprotocol), DBusUint32(flags)]);
+  Future<String> callHostNameResolverPrepare(int interface, int protocol,
+      String name, int aprotocol, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'HostNameResolverPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(name),
+      DBusInt32(aprotocol),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.HostNameResolverPrepare returned invalid values \${result.values}';
     }
@@ -221,8 +305,15 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.AddressResolverPrepare()
-  Future<String> callAddressResolverPrepare(int interface, int protocol, String address, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'AddressResolverPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(address), DBusUint32(flags)]);
+  Future<String> callAddressResolverPrepare(
+      int interface, int protocol, String address, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'AddressResolverPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(address),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.AddressResolverPrepare returned invalid values \${result.values}';
     }
@@ -230,8 +321,17 @@ class AvahiServer2 extends DBusRemoteObject {
   }
 
   /// Invokes org.freedesktop.Avahi.Server2.RecordBrowserPrepare()
-  Future<String> callRecordBrowserPrepare(int interface, int protocol, String name, int clazz, int type, int flags) async {
-    var result = await callMethod('org.freedesktop.Avahi.Server2', 'RecordBrowserPrepare', [DBusInt32(interface), DBusInt32(protocol), DBusString(name), DBusUint16(clazz), DBusUint16(type), DBusUint32(flags)]);
+  Future<String> callRecordBrowserPrepare(int interface, int protocol,
+      String name, int clazz, int type, int flags) async {
+    var result = await callMethod(
+        'org.freedesktop.Avahi.Server2', 'RecordBrowserPrepare', [
+      DBusInt32(interface),
+      DBusInt32(protocol),
+      DBusString(name),
+      DBusUint16(clazz),
+      DBusUint16(type),
+      DBusUint32(flags)
+    ]);
     if (result.signature != DBusSignature('o')) {
       throw 'org.freedesktop.Avahi.Server2.RecordBrowserPrepare returned invalid values \${result.values}';
     }
@@ -240,7 +340,8 @@ class AvahiServer2 extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.Server2.StateChanged.
   Stream<AvahiServer2StateChanged> subscribeStateChanged() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.Server2', 'StateChanged');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.Server2', 'StateChanged');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('is')) {
         return AvahiServer2StateChanged(signal);

--- a/lib/src/avahi_defs/service_browser.dart
+++ b/lib/src/avahi_defs/service_browser.dart
@@ -4,7 +4,7 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.ServiceBrowser.ItemNew.
-class AvahiServiceBrowserItemNew extends DBusSignal{
+class AvahiServiceBrowserItemNew extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get name => (values[2] as DBusString).value;
@@ -12,11 +12,13 @@ class AvahiServiceBrowserItemNew extends DBusSignal{
   String get domain => (values[4] as DBusString).value;
   int get flags => (values[5] as DBusUint32).value;
 
-  AvahiServiceBrowserItemNew(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceBrowserItemNew(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceBrowser.ItemRemove.
-class AvahiServiceBrowserItemRemove extends DBusSignal{
+class AvahiServiceBrowserItemRemove extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get name => (values[2] as DBusString).value;
@@ -24,34 +26,43 @@ class AvahiServiceBrowserItemRemove extends DBusSignal{
   String get domain => (values[4] as DBusString).value;
   int get flags => (values[5] as DBusUint32).value;
 
-  AvahiServiceBrowserItemRemove(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceBrowserItemRemove(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceBrowser.Failure.
-class AvahiServiceBrowserFailure extends DBusSignal{
+class AvahiServiceBrowserFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiServiceBrowserFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceBrowserFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceBrowser.AllForNow.
-class AvahiServiceBrowserAllForNow extends DBusSignal{
-
-  AvahiServiceBrowserAllForNow(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiServiceBrowserAllForNow extends DBusSignal {
+  AvahiServiceBrowserAllForNow(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceBrowser.CacheExhausted.
-class AvahiServiceBrowserCacheExhausted extends DBusSignal{
-
-  AvahiServiceBrowserCacheExhausted(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiServiceBrowserCacheExhausted extends DBusSignal {
+  AvahiServiceBrowserCacheExhausted(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiServiceBrowser extends DBusRemoteObject {
-  AvahiServiceBrowser(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiServiceBrowser(
+      DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -60,7 +71,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceBrowser.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceBrowser', 'Free', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.ServiceBrowser', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceBrowser.Free returned invalid values \${result.values}';
     }
@@ -68,7 +80,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceBrowser.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceBrowser', 'Start', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.ServiceBrowser', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceBrowser.Start returned invalid values \${result.values}';
     }
@@ -76,7 +89,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceBrowser.ItemNew.
   Stream<AvahiServiceBrowserItemNew> subscribeItemNew() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'ItemNew');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'ItemNew');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisssu')) {
         return AvahiServiceBrowserItemNew(signal);
@@ -88,7 +102,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceBrowser.ItemRemove.
   Stream<AvahiServiceBrowserItemRemove> subscribeItemRemove() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'ItemRemove');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'ItemRemove');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iisssu')) {
         return AvahiServiceBrowserItemRemove(signal);
@@ -100,7 +115,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceBrowser.Failure.
   Stream<AvahiServiceBrowserFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiServiceBrowserFailure(signal);
@@ -112,7 +128,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceBrowser.AllForNow.
   Stream<AvahiServiceBrowserAllForNow> subscribeAllForNow() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'AllForNow');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'AllForNow');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiServiceBrowserAllForNow(signal);
@@ -124,7 +141,8 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceBrowser.CacheExhausted.
   Stream<AvahiServiceBrowserCacheExhausted> subscribeCacheExhausted() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceBrowser', 'CacheExhausted');
+    var signals = subscribeSignal(
+        'org.freedesktop.Avahi.ServiceBrowser', 'CacheExhausted');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiServiceBrowserCacheExhausted(signal);

--- a/lib/src/avahi_defs/service_resolver.dart
+++ b/lib/src/avahi_defs/service_resolver.dart
@@ -4,7 +4,7 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.ServiceResolver.Found.
-class AvahiServiceResolverFound extends DBusSignal{
+class AvahiServiceResolverFound extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get name => (values[2] as DBusString).value;
@@ -14,25 +14,38 @@ class AvahiServiceResolverFound extends DBusSignal{
   int get aprotocol => (values[6] as DBusInt32).value;
   String get address => (values[7] as DBusString).value;
   int get port => (values[8] as DBusUint16).value;
-  List<List<int>> get txt => (values[9] as DBusArray).children.map((child) => (child as DBusArray).children.map((child) => (child as DBusByte).value).toList()).toList();
+  List<List<int>> get txt => (values[9] as DBusArray)
+      .children
+      .map((child) => (child as DBusArray)
+          .children
+          .map((child) => (child as DBusByte).value)
+          .toList())
+      .toList();
   int get flags => (values[10] as DBusUint32).value;
 
-  AvahiServiceResolverFound(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceResolverFound(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceResolver.Failure.
-class AvahiServiceResolverFailure extends DBusSignal{
+class AvahiServiceResolverFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiServiceResolverFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceResolverFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiServiceResolver extends DBusRemoteObject {
-  AvahiServiceResolver(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiServiceResolver(
+      DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -41,7 +54,8 @@ class AvahiServiceResolver extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceResolver.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceResolver', 'Free', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.ServiceResolver', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceResolver.Free returned invalid values \${result.values}';
     }
@@ -49,7 +63,8 @@ class AvahiServiceResolver extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceResolver.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceResolver', 'Start', []);
+    var result =
+        await callMethod('org.freedesktop.Avahi.ServiceResolver', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceResolver.Start returned invalid values \${result.values}';
     }
@@ -57,7 +72,8 @@ class AvahiServiceResolver extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceResolver.Found.
   Stream<AvahiServiceResolverFound> subscribeFound() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceResolver', 'Found');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceResolver', 'Found');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iissssisqaayu')) {
         return AvahiServiceResolverFound(signal);
@@ -69,7 +85,8 @@ class AvahiServiceResolver extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceResolver.Failure.
   Stream<AvahiServiceResolverFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceResolver', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceResolver', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiServiceResolverFailure(signal);

--- a/lib/src/avahi_defs/service_type_browser.dart
+++ b/lib/src/avahi_defs/service_type_browser.dart
@@ -4,52 +4,63 @@
 import 'package:dbus/dbus.dart';
 
 /// Signal data for org.freedesktop.Avahi.ServiceTypeBrowser.ItemNew.
-class AvahiServiceTypeBrowserItemNew extends DBusSignal{
+class AvahiServiceTypeBrowserItemNew extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get type => (values[2] as DBusString).value;
   String get domain => (values[3] as DBusString).value;
   int get flags => (values[4] as DBusUint32).value;
 
-  AvahiServiceTypeBrowserItemNew(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceTypeBrowserItemNew(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceTypeBrowser.ItemRemove.
-class AvahiServiceTypeBrowserItemRemove extends DBusSignal{
+class AvahiServiceTypeBrowserItemRemove extends DBusSignal {
   int get interface_ => (values[0] as DBusInt32).value;
   int get protocol => (values[1] as DBusInt32).value;
   String get type => (values[2] as DBusString).value;
   String get domain => (values[3] as DBusString).value;
   int get flags => (values[4] as DBusUint32).value;
 
-  AvahiServiceTypeBrowserItemRemove(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceTypeBrowserItemRemove(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceTypeBrowser.Failure.
-class AvahiServiceTypeBrowserFailure extends DBusSignal{
+class AvahiServiceTypeBrowserFailure extends DBusSignal {
   String get error => (values[0] as DBusString).value;
 
-  AvahiServiceTypeBrowserFailure(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+  AvahiServiceTypeBrowserFailure(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceTypeBrowser.AllForNow.
-class AvahiServiceTypeBrowserAllForNow extends DBusSignal{
-
-  AvahiServiceTypeBrowserAllForNow(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiServiceTypeBrowserAllForNow extends DBusSignal {
+  AvahiServiceTypeBrowserAllForNow(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 /// Signal data for org.freedesktop.Avahi.ServiceTypeBrowser.CacheExhausted.
-class AvahiServiceTypeBrowserCacheExhausted extends DBusSignal{
-
-  AvahiServiceTypeBrowserCacheExhausted(DBusSignal signal) : super(signal.sender, signal.path, signal.interface, signal.name, signal.values);
+class AvahiServiceTypeBrowserCacheExhausted extends DBusSignal {
+  AvahiServiceTypeBrowserCacheExhausted(DBusSignal signal)
+      : super(signal.sender, signal.path, signal.interface, signal.name,
+            signal.values);
 }
 
 class AvahiServiceTypeBrowser extends DBusRemoteObject {
-  AvahiServiceTypeBrowser(DBusClient client, String destination, DBusObjectPath path) : super(client, destination, path);
+  AvahiServiceTypeBrowser(
+      DBusClient client, String destination, DBusObjectPath path)
+      : super(client, destination, path);
 
   /// Invokes org.freedesktop.DBus.Introspectable.Introspect()
   Future<String> callIntrospect() async {
-    var result = await callMethod('org.freedesktop.DBus.Introspectable', 'Introspect', []);
+    var result = await callMethod(
+        'org.freedesktop.DBus.Introspectable', 'Introspect', []);
     if (result.signature != DBusSignature('s')) {
       throw 'org.freedesktop.DBus.Introspectable.Introspect returned invalid values \${result.values}';
     }
@@ -58,7 +69,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceTypeBrowser.Free()
   Future<void> callFree() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceTypeBrowser', 'Free', []);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.ServiceTypeBrowser', 'Free', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceTypeBrowser.Free returned invalid values \${result.values}';
     }
@@ -66,7 +78,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceTypeBrowser.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceTypeBrowser', 'Start', []);
+    var result = await callMethod(
+        'org.freedesktop.Avahi.ServiceTypeBrowser', 'Start', []);
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceTypeBrowser.Start returned invalid values \${result.values}';
     }
@@ -74,7 +87,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceTypeBrowser.ItemNew.
   Stream<AvahiServiceTypeBrowserItemNew> subscribeItemNew() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'ItemNew');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'ItemNew');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iissu')) {
         return AvahiServiceTypeBrowserItemNew(signal);
@@ -86,7 +100,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceTypeBrowser.ItemRemove.
   Stream<AvahiServiceTypeBrowserItemRemove> subscribeItemRemove() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'ItemRemove');
+    var signals = subscribeSignal(
+        'org.freedesktop.Avahi.ServiceTypeBrowser', 'ItemRemove');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('iissu')) {
         return AvahiServiceTypeBrowserItemRemove(signal);
@@ -98,7 +113,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceTypeBrowser.Failure.
   Stream<AvahiServiceTypeBrowserFailure> subscribeFailure() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'Failure');
+    var signals =
+        subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'Failure');
     return signals.map((signal) {
       if (signal.signature == DBusSignature('s')) {
         return AvahiServiceTypeBrowserFailure(signal);
@@ -110,7 +126,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceTypeBrowser.AllForNow.
   Stream<AvahiServiceTypeBrowserAllForNow> subscribeAllForNow() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'AllForNow');
+    var signals = subscribeSignal(
+        'org.freedesktop.Avahi.ServiceTypeBrowser', 'AllForNow');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiServiceTypeBrowserAllForNow(signal);
@@ -122,7 +139,8 @@ class AvahiServiceTypeBrowser extends DBusRemoteObject {
 
   /// Subscribes to org.freedesktop.Avahi.ServiceTypeBrowser.CacheExhausted.
   Stream<AvahiServiceTypeBrowserCacheExhausted> subscribeCacheExhausted() {
-    var signals = subscribeSignal('org.freedesktop.Avahi.ServiceTypeBrowser', 'CacheExhausted');
+    var signals = subscribeSignal(
+        'org.freedesktop.Avahi.ServiceTypeBrowser', 'CacheExhausted');
     return signals.map((signal) {
       if (signal.values.isEmpty) {
         return AvahiServiceTypeBrowserCacheExhausted(signal);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -134,7 +134,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR updates the discovery code to use the Server2 Avahi API if it's available, so that the workaround used for the old D-Bus API can be skipped from the main code. 