### PR TITLE
Add e2e and external API sanity checks

### DIFF
--- a/lib/src/avahi_defs/service_browser.dart
+++ b/lib/src/avahi_defs/service_browser.dart
@@ -68,7 +68,7 @@ class AvahiServiceBrowser extends DBusRemoteObject {
 
   /// Invokes org.freedesktop.Avahi.ServiceBrowser.Start()
   Future<void> callStart() async {
-    var result = await callMethod('org.freedesktop.Avahi.ServiceBrowser', 'Start', []);
+    var result = await callMethod('org.freedesktop.Avahi.ServiceBrowser', 'Start', [], flags: {DBusMethodCallFlag.noReplyExpected});
     if (result.signature != DBusSignature('')) {
       throw 'org.freedesktop.Avahi.ServiceBrowser.Start returned invalid values \${result.values}';
     }

--- a/lib/src/linux_dbus_bonsoir_broadcast.dart
+++ b/lib/src/linux_dbus_bonsoir_broadcast.dart
@@ -37,18 +37,17 @@ class LinuxDBusBonsoirBroadcast
       ),
     );
     await sendServiceToAvahi(this.service);
+    _controller = StreamController();
   }
 
   @override
   Future<void> start() async {
-    _controller = StreamController.broadcast();
+    
     _subscriptions['StateChanged'] =
         _entryGroup.subscribeStateChanged().listen((event) {
       switch (event.state.toAvahiEntryGroupState()) {
         case AvahiEntryGroupState.AVAHI_ENTRY_GROUP_UNCOMMITED:
         case AvahiEntryGroupState.AVAHI_ENTRY_GROUP_REGISTERING:
-          // TODO: Separate the events
-          _controller!.add(BonsoirStaticClasses.unknownEvent);
           break;
         case AvahiEntryGroupState.AVAHI_ENTRY_GROUP_ESTABLISHED:
           _controller!.add(BonsoirBroadcastEvent(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -134,7 +134,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/test/bonsoir_linux_dbus_test.dart
+++ b/test/bonsoir_linux_dbus_test.dart
@@ -1,5 +1,130 @@
+import 'package:bonsoir_platform_interface/bonsoir_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'dart:io' show Platform;
 import 'package:bonsoir_linux_dbus/bonsoir_linux_dbus.dart';
 
-void main() {}
+@TestOn('linux && vm')
+void main() {
+  group('external_api', () {
+    test('Able to create a discovery without D-Bus complaining', () async {
+      var api = BonsoirLinuxDBus();
+      var discover = api.createDiscovery('_bonsoirlinux._tcp', printLogs: true);
+      await discover.ready;
+      await discover.start();
+      // Await the workaround
+      await Future.delayed(Duration(seconds: 1));
+      await discover.stop();
+    });
+    test('Able to create a broadcast without D-Bus complaining', () async {
+      var api = BonsoirLinuxDBus();
+      var broadcast = api.createBroadcast(
+          BonsoirService(
+              name: "Bonsoir example service",
+              type: "_bonsoirlinux._tcp",
+              port: 3000),
+          printLogs: true);
+      await broadcast.ready;
+      await broadcast.start();
+      await broadcast.stop();
+    });
+    test('Broadcast sends expected messages', () async {
+      var api = BonsoirLinuxDBus();
+      var broadcast = api.createBroadcast(
+          BonsoirService(
+              name: "Bonsoir example service",
+              type: "_bonsoirlinux._tcp",
+              port: 3000),
+          printLogs: true);
+      await broadcast.ready;
+      var future = expectLater(
+        broadcast.eventStream,
+        emitsInOrder([
+          predicate<BonsoirBroadcastEvent>(
+              (event) =>
+                  event.type == BonsoirBroadcastEventType.BROADCAST_STARTED,
+              "has type == BROADCAST_STARTED"),
+          predicate<BonsoirBroadcastEvent>(
+              (event) =>
+                  event.type == BonsoirBroadcastEventType.BROADCAST_STOPPED,
+              "has type == BROADCAST_STOPPED"),
+          emitsDone
+        ]),
+      );
+      await broadcast.start();
+      // Wait for the announcement to start.
+      await Future.delayed(Duration(seconds: 1));
+      await broadcast.stop();
+      await future;
+    });
+  }, skip: Platform.isLinux ? null : "Test can only be run on Linux");
+  group('end-to-end', () {
+    test('Broadcast name and receive them on service enumeration', () async {
+      var api = BonsoirLinuxDBus();
+      const svcName = "Test service for numeration";
+      const svcType = "_bonsoire2e._tcp";
+      const svcPort = 3000;
+      var bcast = api.createBroadcast(
+          BonsoirService(name: svcName, type: svcType, port: svcPort),
+          printLogs: true);
+      var discover = api.createDiscovery("_bonsoire2e._tcp", printLogs: true);
+      await Future.wait([bcast.ready, discover.ready]);
+      bool resolvedAtLeastOnce = false;
+      bool lostAtLeastOnce = false;
+      bool foundAtLeastOnce = false;
+      var expected = expectLater(
+          discover.eventStream,
+          emitsInAnyOrder([
+            predicate<BonsoirDiscoveryEvent>(
+                (event) =>
+                    event.type == BonsoirDiscoveryEventType.DISCOVERY_STARTED,
+                "had eventType DiscoveryStarted"),
+            mayEmitMultiple(predicate<BonsoirDiscoveryEvent>((event) {
+              var found = event.type ==
+                  BonsoirDiscoveryEventType.DISCOVERY_SERVICE_FOUND;
+              if (found) {
+                foundAtLeastOnce = true;
+                return found;
+              }
+              return false;
+            }, "had eventType ServiceFound")),
+            mayEmitMultiple(predicate<BonsoirDiscoveryEvent>((event) {
+              if (event.type ==
+                  BonsoirDiscoveryEventType.DISCOVERY_SERVICE_RESOLVED) {
+                if (event.isServiceResolved) {
+                  var resolved = event.service as ResolvedBonsoirService;
+                  var matchService = resolved.name == svcName &&
+                      resolved.port == svcPort &&
+                      resolved.type == svcType;
+                  if (matchService) {
+                    resolvedAtLeastOnce = true;
+                    return matchService;
+                  }
+                }
+              }
+              return false;
+            }, "matches the service type broadcasted first")),
+            mayEmitMultiple(predicate<BonsoirDiscoveryEvent>((event) {
+              var lost = event.type ==
+                  BonsoirDiscoveryEventType.DISCOVERY_SERVICE_LOST;
+              if (lost) {
+                lostAtLeastOnce = true;
+                return lost;
+              }
+              return false;
+            }, "has eventType == ServiceLost")),
+            predicate<BonsoirDiscoveryEvent>(
+                (event) =>
+                    event.type == BonsoirDiscoveryEventType.DISCOVERY_STOPPED,
+                "has eventType == Stopped")
+          ]));
+      await Future.wait([bcast.start(), discover.start()]);
+      await Future.delayed(Duration(seconds: 2));
+      await bcast.stop();
+      await Future.delayed(Duration(seconds: 2));
+      await discover.stop();
+      await expected;
+      expect(
+          resolvedAtLeastOnce && lostAtLeastOnce && foundAtLeastOnce, isTrue);
+    });
+  });
+}

--- a/test/bonsoir_linux_dbus_test.dart
+++ b/test/bonsoir_linux_dbus_test.dart
@@ -94,7 +94,8 @@ void main() {
                   var resolved = event.service as ResolvedBonsoirService;
                   var matchService = resolved.name == svcName &&
                       resolved.port == svcPort &&
-                      resolved.type == svcType;
+                      resolved.type == svcType &&
+                      resolved.ip!.isNotEmpty;
                   if (matchService) {
                     resolvedAtLeastOnce = true;
                     return matchService;


### PR DESCRIPTION
This PR adds tests making sure the external API supports basic functionality (no exceptions are expected), and adds a end-to-end test that makes sure that the eventStream emits the right events with the right information.