### PR TITLE
Fix service name

### DIFF
--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -26,7 +26,7 @@ extension KGBrowser on AvahiServiceBrowserItemRemove {
 ResolvedBonsoirService bonsoirServiceFromFoundService(
     AvahiServiceResolverFound resolvedService) {
   return ResolvedBonsoirService(
-      name: resolvedService.name,
+      name: resolvedService.serviceName,
       type: resolvedService.type,
       ip: resolvedService.address,
       port: resolvedService.port,


### PR DESCRIPTION
`ResolvedBonsoirService.name` was coming from `AvahiServiceResolverFound.name` which contains the DBus event name  so it's always just 'Found' for resolved services instead of the resolver mDNS service name.